### PR TITLE
Basic CSS for the Desktop Version

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,17 @@
+.bg-image {
+    /* The image used */
+    background-image: url("../assets/coming_soon.png");
+  
+    /* Full height */
+    height: 100%; 
+  
+    /* Center and scale the image nicely */
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+}
+
+img.bg-image{
+    width:100%;
+    height:auto;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,1 @@
-<img src="../assets/coming_soon.png" alt="Coming Soon" />
+<div class="bg-image"></div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -64,3 +64,8 @@ div {
   font-size: 89px;
   text-transform: uppercase;
 }
+
+body, html {
+  height: 100%;
+  margin: 0;
+}


### PR DESCRIPTION
**Changes**

- Added a `div` carrying a class to for the image
- CSS changes works only for desktop version and some tablets. A robust solution must be introduced for responsive UI.
- Now background occupies full page.